### PR TITLE
fix: 修复 URI malformed 错误

### DIFF
--- a/docs/old-code-backup/js-cookie-monitor-debugger-hook.js
+++ b/docs/old-code-backup/js-cookie-monitor-debugger-hook.js
@@ -323,6 +323,20 @@
         }
 
         /**
+         * 安全地解码 URI 组件
+         * @param str
+         * @returns {string}
+         */
+        function safeDecode(str) {
+            try {
+                return decodeURIComponent(str);
+            } catch (e) {
+                // 出错就原样返回，避免 URI malformed
+                return str;
+            }
+        }
+
+        /**
          * 把按照等号=拼接的key、value字符串切分开
          * @param s
          * @returns {{value: string, key: string}}
@@ -332,11 +346,11 @@
             const keyValueArray = (s || "").split("=");
 
             if (keyValueArray.length) {
-                key = decodeURIComponent(keyValueArray[0].trim());
+                key = safeDecode(keyValueArray[0].trim());
             }
 
             if (keyValueArray.length > 1) {
-                value = decodeURIComponent(keyValueArray.slice(1).join("=").trim());
+                value = safeDecode(keyValueArray.slice(1).join("=").trim());
             }
 
             return {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -14,6 +14,20 @@ export function genFormatArray(messageAndStyleArray: string[]): string {
 }
 
 /**
+ * 安全地解码 URI 组件
+ * @param str
+ * @returns 解码后的字符串
+ */
+function safeDecode(str: string) {
+    try {
+        return decodeURIComponent(str);
+    } catch (e) {
+        // 出错就原样返回，避免 URI malformed
+        return str;
+    }
+}
+
+/**
  * 把按照等号=拼接的key、value字符串切分开
  * @param s 包含键值对的字符串
  * @returns 切分后的键值对对象
@@ -23,11 +37,11 @@ export function splitKeyValue(s: string): KeyValuePair {
     const keyValueArray = (s || "").split("=");
 
     if (keyValueArray.length) {
-        key = decodeURIComponent(keyValueArray[0].trim());
+        key = safeDecode(keyValueArray[0].trim());
     }
 
     if (keyValueArray.length > 1) {
-        value = decodeURIComponent(keyValueArray.slice(1).join("=").trim());
+        value = safeDecode(keyValueArray.slice(1).join("=").trim());
     }
 
     return {


### PR DESCRIPTION
当 cookie 中包含不合法 URL encode 字段时，直接 decode 会报 Uncaught URIError: URI malformed 错误，导致看不到原始内容，如 12306 网站

修改为: 解析错误时返回原始内容

<img width="500" alt="Snipaste_2025-09-28_18-02-26" src="https://github.com/user-attachments/assets/92f2a051-1661-4184-9545-69439ba33411" />
